### PR TITLE
Adiciona dominio de Contratos consumindo o bi-portal-data

### DIFF
--- a/src/data/loadContratos.ts
+++ b/src/data/loadContratos.ts
@@ -1,0 +1,37 @@
+import axios from "axios";
+
+/**
+ * Acesso aos dados de Contratos de Repasses / Convênios, servidos pelo
+ * bi-portal-data.
+ *
+ * Origem: aba PRATA da planilha "TOP - OBRAS BI", a mesma que alimenta o
+ * painel no Looker Studio. O grão de cada registro é um contrato/convênio.
+ */
+
+const BASE_URL = `${process.env.DATA_API_URL}/api/contratos`;
+
+export async function getContratosData(path: string, filters?: Record<string, any>) {
+  try {
+    const query = buildQueryParams(filters || {});
+    const url = `${BASE_URL}/${path}${query}`;
+
+    const response = await axios.get(url, {
+      headers: {
+        'X-API-Key': process.env.API_SECRET_KEY,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error(`❌ Erro ao buscar rota de Contratos - ${path}:`, error);
+    throw new Error(`Erro ao acessar rota de Contratos - ${path}`);
+  }
+}
+
+function buildQueryParams(params: Record<string, any>) {
+  const query = Object.entries(params)
+    .filter(([_, value]) => value !== undefined && value !== null && value !== "")
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join("&");
+
+  return query ? `?${query}` : "";
+}

--- a/src/schema/contratos/contratos.resolver.ts
+++ b/src/schema/contratos/contratos.resolver.ts
@@ -1,0 +1,69 @@
+import { ContratosService } from './contratos.service';
+import { ContratosFilters } from './utils/types';
+
+type ContratosContext = { contratosService: ContratosService };
+
+const requireService = (context: ContratosContext, queryName: string) => {
+  const service = context.contratosService;
+  if (!service) throw new Error(`${queryName} não inicializado`);
+  return service;
+};
+
+export const contratosResolvers = () => ({
+  Query: {
+    getContratos: async (
+      _: unknown,
+      { filters }: { filters?: ContratosFilters },
+      context: ContratosContext
+    ) => {
+      return await requireService(context, 'getContratos').getContratos(filters);
+    },
+
+    getContratosSecretariaSummary: async (
+      _: unknown,
+      { filters }: { filters?: ContratosFilters },
+      context: ContratosContext
+    ) => {
+      return await requireService(context, 'getContratosSecretariaSummary').getSecretariaSummary(filters);
+    },
+
+    getContratosTable: async (_: unknown, args: any, context: ContratosContext) => {
+      return await requireService(context, 'getContratosTable').getContratosTableData(
+        args.limit,
+        args.offset,
+        args.sortBy,
+        args.sortDirection,
+        args.filters,
+        args.tableFilters
+      );
+    },
+
+    getContratosKpi: async (
+      _: unknown,
+      { filters }: { filters?: ContratosFilters },
+      context: ContratosContext
+    ) => {
+      return await requireService(context, 'getContratosKpi').getKpi(filters);
+    },
+
+    getContratosCharts: async (
+      _: unknown,
+      { filters }: { filters?: ContratosFilters },
+      context: ContratosContext
+    ) => {
+      return await requireService(context, 'getContratosCharts').getCharts(filters);
+    },
+
+    getContratosFiltersOptions: async (
+      _: unknown,
+      { filters }: { filters?: ContratosFilters },
+      context: ContratosContext
+    ) => {
+      return await requireService(context, 'getContratosFiltersOptions').getFilterOptions(filters);
+    },
+
+    getContratosLastUpdate: async (_: unknown, __: any, context: ContratosContext) => {
+      return await requireService(context, 'getContratosLastUpdate').getContratosLastUpdate();
+    },
+  },
+});

--- a/src/schema/contratos/contratos.schema.graphql
+++ b/src/schema/contratos/contratos.schema.graphql
@@ -1,0 +1,148 @@
+scalar DateTime
+
+# A origem não tem data, só o ano do contrato — o período é filtrado por ano.
+input YearRangeInput {
+  from: Int
+  to: Int
+}
+
+input ContratosFilters {
+  yearRange: YearRangeInput
+  processNumber: String
+  resourceSource: String
+  parliamentarian: String
+  departmentCode: String
+  neighborhood: String
+  area: String
+  status: String
+  description: String
+}
+
+input ContratosFiltersOptions {
+  yearRange: YearRangeInput
+  processNumber: String
+  resourceSource: String
+  parliamentarian: String
+  departmentCode: String
+  neighborhood: String
+  area: String
+  status: String
+  description: String
+}
+
+input ContratosTableFilters {
+  processNumber: String
+  year: String
+  departmentCode: String
+  parliamentarian: String
+  resourceSource: String
+  area: String
+  neighborhood: String
+  description: String
+  status: String
+}
+
+type ContratosKpiData {
+  totalRepasse: Float
+  totalContrapartida: Float
+  totalGlobal: Float
+  totalContratos: Int
+  totalProcessos: Int
+}
+
+type ContratosChartItem {
+  name: String
+  total: Float
+}
+
+type ContratosCharts {
+  ValorPorAno: [ContratosChartItem]
+  ValorPorSecretaria: [ContratosChartItem]
+  ValorPorParlamentar: [ContratosChartItem]
+  ValorPorArea: [ContratosChartItem]
+  ValorPorFonte: [ContratosChartItem]
+  ContratosPorStatus: [ContratosChartItem]
+}
+
+# Linha da tabela (grão = contrato/convênio)
+type ContratoTable {
+  id: String
+  processNumber: String
+  year: Int
+  departmentCode: String
+  parliamentarian: String
+  resourceSource: String
+  area: String
+  neighborhood: String
+  description: String
+  transferAmount: Float
+  counterpartAmount: Float
+  globalAmount: Float
+  status: String
+}
+
+type ContratosTableResponse {
+  data: [ContratoTable]
+  totalCount: Int!
+}
+
+# Registro completo, usado no download da fonte de dados
+type Contrato {
+  id: String
+  processNumber: String
+  year: Int
+  resourceSource: String
+  parliamentarian: String
+  departmentCode: String
+  description: String
+  neighborhood: String
+  area: String
+  transferAmount: Float
+  counterpartAmount: Float
+  globalAmount: Float
+  status: String
+  statusRaw: String
+}
+
+type ContratosSecretariaSummary {
+  departmentCode: String
+  totalRepasse: Float
+  totalContrapartida: Float
+  totalGlobal: Float
+  contratoCount: Int
+}
+
+type FilterOption {
+  value: String
+  label: String
+}
+
+type FilterOptionsContratos {
+  year: [FilterOption]
+  processNumber: [FilterOption]
+  resourceSource: [FilterOption]
+  parliamentarian: [FilterOption]
+  departmentCode: [FilterOption]
+  neighborhood: [FilterOption]
+  area: [FilterOption]
+  status: [FilterOption]
+}
+
+type Query {
+  getContratos(filters: ContratosFilters): [Contrato]
+  getContratosSecretariaSummary(filters: ContratosFilters): [ContratosSecretariaSummary]
+
+  getContratosTable(
+    limit: Int
+    offset: Int
+    sortBy: String
+    sortDirection: String
+    filters: ContratosFilters
+    tableFilters: ContratosTableFilters
+  ): ContratosTableResponse
+
+  getContratosLastUpdate: DateTime
+  getContratosKpi(filters: ContratosFilters): ContratosKpiData
+  getContratosCharts(filters: ContratosFilters): ContratosCharts
+  getContratosFiltersOptions(filters: ContratosFiltersOptions): FilterOptionsContratos
+}

--- a/src/schema/contratos/contratos.service.ts
+++ b/src/schema/contratos/contratos.service.ts
@@ -1,0 +1,147 @@
+import { getContratosData } from '../../data/loadContratos';
+import { Processor } from '../../utils/processor';
+import { mapContratosFiltersToApiParams } from './utils/mapToProcessed';
+import {
+  Contrato,
+  ContratosFilters,
+  ContratosKpiData,
+  ContratosTableFilters,
+  ContratoTableRow,
+  PaginatedContratosResponse,
+} from './utils/types';
+
+const isBlank = (v: any) => v === null || v === undefined || v === '';
+
+const contains = (value: any, needle?: string) => {
+  if (isBlank(needle)) return true;
+  if (isBlank(value)) return false;
+  return String(value).toLowerCase().includes(String(needle).toLowerCase());
+};
+
+const toNumber = (v: any) => {
+  const n = Number(v);
+  return isNaN(n) ? 0 : n;
+};
+
+export class ContratosService {
+  static async create(): Promise<ContratosService> {
+    // A carga fica no bi-portal-data; nada é mantido em memória aqui.
+    return new ContratosService();
+  }
+
+  public async getContratos(filters?: ContratosFilters): Promise<Contrato[]> {
+    const params = mapContratosFiltersToApiParams(filters);
+    return await getContratosData("all", params);
+  }
+
+  public async getContratosTableData(
+    limit?: number,
+    offset?: number,
+    sortBy?: string,
+    sortDirection?: any,
+    filters?: ContratosFilters,
+    tableFilters?: ContratosTableFilters
+  ): Promise<PaginatedContratosResponse> {
+    const params = mapContratosFiltersToApiParams(filters);
+    let data: ContratoTableRow[] = await getContratosData("table_data", params);
+
+    if (tableFilters) {
+      data = data.filter((item) =>
+        (Object.keys(tableFilters) as Array<keyof ContratosTableFilters>).every((key) =>
+          contains(item[key as keyof ContratoTableRow], tableFilters[key])
+        )
+      );
+    }
+
+    data = Processor.sortData(data, sortBy, sortDirection || 'ascending');
+    const totalCount = data.length;
+
+    // O offset é opcional: pedir só o limit deve devolver a primeira página,
+    // e não a lista inteira.
+    if (typeof limit === 'number') {
+      const inicio = typeof offset === 'number' ? offset : 0;
+      data = data.slice(inicio, inicio + limit);
+    }
+
+    return { data, totalCount };
+  }
+
+  public async getContratosLastUpdate(): Promise<string | null> {
+    const data = await getContratosData("kpi/last_update");
+    return data?.last_update ?? null;
+  }
+
+  public async getKpi(filters?: ContratosFilters): Promise<ContratosKpiData> {
+    const params = mapContratosFiltersToApiParams(filters);
+    const data = await getContratosData("kpis/gerais", params);
+    const r = data?.resultados ?? {};
+
+    return {
+      totalRepasse: toNumber(r.total_repasse),
+      totalContrapartida: toNumber(r.total_contrapartida),
+      totalGlobal: toNumber(r.total_global),
+      totalContratos: toNumber(r.total_contratos),
+      // O mesmo processo pode ter mais de um registro, por isso a contagem
+      // distinta fica separada do total de linhas.
+      totalProcessos: toNumber(r.total_processos_unicos),
+    };
+  }
+
+  public async getCharts(filters?: ContratosFilters) {
+    const params = mapContratosFiltersToApiParams(filters);
+
+    const [ano, secretaria, parlamentar, area, fonte, status] = await Promise.all([
+      getContratosData("dashboard/por_ano", params),
+      getContratosData("dashboard/por_secretaria", params),
+      getContratosData("dashboard/por_parlamentar", params),
+      getContratosData("dashboard/por_area", params),
+      getContratosData("dashboard/por_fonte", params),
+      getContratosData("dashboard/por_status", params),
+    ]);
+
+    const serie = (payload: any) =>
+      (payload?.resultados ?? []).map((item: any) => ({
+        name: item.name,
+        total: toNumber(item.total),
+      }));
+
+    return {
+      ValorPorAno: serie(ano),
+      ValorPorSecretaria: serie(secretaria),
+      ValorPorParlamentar: serie(parlamentar),
+      ValorPorArea: serie(area),
+      ValorPorFonte: serie(fonte),
+      ContratosPorStatus: serie(status),
+    };
+  }
+
+  public async getFilterOptions(filters?: ContratosFilters) {
+    // A cascata (cada filtro sem se auto-restringir) é resolvida no bi-portal-data.
+    const params = mapContratosFiltersToApiParams(filters);
+    const data = await getContratosData("filterOptions", params);
+
+    return {
+      year: data?.anoOptions ?? [],
+      processNumber: data?.processoOptions ?? [],
+      resourceSource: data?.fonteOptions ?? [],
+      parliamentarian: data?.parlamentarOptions ?? [],
+      departmentCode: data?.secretariaOptions ?? [],
+      neighborhood: data?.bairroOptions ?? [],
+      area: data?.areaOptions ?? [],
+      status: data?.statusOptions ?? [],
+    };
+  }
+
+  public async getSecretariaSummary(filters?: ContratosFilters) {
+    const params = mapContratosFiltersToApiParams(filters);
+    const data = await getContratosData("resumo_por_secretaria", params);
+
+    return (data ?? []).map((item: any) => ({
+      departmentCode: item.departmentCode,
+      totalRepasse: toNumber(item.totalRepasse),
+      totalContrapartida: toNumber(item.totalContrapartida),
+      totalGlobal: toNumber(item.totalGlobal),
+      contratoCount: toNumber(item.contratoCount),
+    }));
+  }
+}

--- a/src/schema/contratos/utils/mapToProcessed.ts
+++ b/src/schema/contratos/utils/mapToProcessed.ts
@@ -1,0 +1,32 @@
+import { ContratosFilters } from './types';
+
+/**
+ * Traduz os filtros do painel para os parâmetros da rota de Contratos
+ * no bi-portal-data.
+ */
+export function mapContratosFiltersToApiParams(
+  filters?: Partial<ContratosFilters>,
+): Record<string, string> {
+  const params: Record<string, string> = {};
+
+  // O período é por ano: a origem não tem data.
+  if (filters?.yearRange?.from) params.ano_inicial = String(filters.yearRange.from);
+  if (filters?.yearRange?.to) params.ano_final = String(filters.yearRange.to);
+
+  const addParam = (key: string, value: any) => {
+    if (value !== undefined && value !== null && value !== "") {
+      params[key] = String(value);
+    }
+  };
+
+  addParam("processo", filters?.processNumber);
+  addParam("fonte", filters?.resourceSource);
+  addParam("parlamentar", filters?.parliamentarian);
+  addParam("secretaria", filters?.departmentCode);
+  addParam("bairro", filters?.neighborhood);
+  addParam("area", filters?.area);
+  addParam("status", filters?.status);
+  addParam("descricao", filters?.description);
+
+  return params;
+}

--- a/src/schema/contratos/utils/types.ts
+++ b/src/schema/contratos/utils/types.ts
@@ -1,0 +1,74 @@
+/** Contrato de repasse ou convênio, como servido pelo bi-portal-data. */
+export interface Contrato {
+  id: number | string | null;
+  processNumber: string | null;
+  year: number | null;
+  resourceSource: string | null;
+  parliamentarian: string | null;
+  departmentCode: string | null;
+  description: string | null;
+  neighborhood: string | null;
+  area: string | null;
+  transferAmount: number;
+  counterpartAmount: number;
+  globalAmount: number;
+  status: string | null;
+  statusRaw: string | null;
+}
+
+/**
+ * A origem não tem coluna de data, só o ano do contrato — por isso o
+ * período é filtrado por ano, e não por intervalo de datas.
+ */
+export interface ContratosFilters {
+  yearRange?: { from?: number; to?: number };
+  processNumber?: string;
+  resourceSource?: string;
+  parliamentarian?: string;
+  departmentCode?: string;
+  neighborhood?: string;
+  area?: string;
+  status?: string;
+  description?: string;
+}
+
+export interface ContratosTableFilters {
+  processNumber?: string;
+  year?: string;
+  departmentCode?: string;
+  parliamentarian?: string;
+  resourceSource?: string;
+  area?: string;
+  neighborhood?: string;
+  description?: string;
+  status?: string;
+}
+
+export interface ContratoTableRow {
+  id: number | string | null;
+  processNumber: string | null;
+  year: number | null;
+  departmentCode: string | null;
+  parliamentarian: string | null;
+  resourceSource: string | null;
+  area: string | null;
+  neighborhood: string | null;
+  description: string | null;
+  transferAmount: number;
+  counterpartAmount: number;
+  globalAmount: number;
+  status: string | null;
+}
+
+export interface PaginatedContratosResponse {
+  data: ContratoTableRow[];
+  totalCount: number;
+}
+
+export interface ContratosKpiData {
+  totalRepasse: number;
+  totalContrapartida: number;
+  totalGlobal: number;
+  totalContratos: number;
+  totalProcessos: number;
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -9,6 +9,7 @@ import abastecimentoResolver from './abastecimento/abastecimento.resolver';
 import osResolvers from './os/os.resolver';
 import { manutencaoResolvers } from './manutenção/manutencao.resolver';
 import { obrasResolvers } from './obras/obras.resolver';
+import { contratosResolvers } from './contratos/contratos.resolver';
 import { suprimentoResolver } from './suprimentos/suprimento.resolver';
 
 export const buildSchema = async (app: FastifyInstance) => {
@@ -24,6 +25,7 @@ export const buildSchema = async (app: FastifyInstance) => {
     abastecimentoResolver,
     manutencaoResolvers(),
     obrasResolvers(),
+    contratosResolvers(),
     osResolvers(),
     suprimentoResolver(),
   ]);

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { buildSchema } from './schema/index';
 import { SuprimentoService } from './schema/suprimentos/suprimento.service';
 import { DiariasService } from './schema/diarias/diarias.service';
 import { ObrasService } from './schema/obras/obras.service';
+import { ContratosService } from './schema/contratos/contratos.service';
 
 export async function buildServer() {
   const isDev = process.env.NODE_ENV !== 'PRODUCTION';
@@ -58,11 +59,12 @@ export async function buildServer() {
   }));
 
   // Inicializa serviço
-  const [abastecimento, diarias, obras, suprimento] = await Promise.allSettled([
+  const [abastecimento, diarias, obras, suprimento, contratos] = await Promise.allSettled([
     AbastecimentoService.create(),
     DiariasService.create(),
     ObrasService.create(),
-    SuprimentoService.create()
+    SuprimentoService.create(),
+    ContratosService.create()
   ]);
 
   if (abastecimento.status === 'fulfilled')
@@ -85,6 +87,11 @@ export async function buildServer() {
   else
     console.error('Erro ao inicializar SuprimentoService:', suprimento.reason);
 
+  if (contratos.status === 'fulfilled')
+    console.log('🚀 ContratosService inicializado!');
+  else
+    console.error('Erro ao inicializar ContratosService:', contratos.reason);
+
   const abastecimentoService =
     abastecimento.status === 'fulfilled' ? abastecimento.value : null;
   const diariasService =
@@ -93,6 +100,8 @@ export async function buildServer() {
     obras.status === 'fulfilled' ? obras.value : null;
   const suprimentoService =
     suprimento.status === 'fulfilled' ? suprimento.value : null;
+  const contratosService =
+    contratos.status === 'fulfilled' ? contratos.value : null;
 
   // Schema GraphQL
   const schema = await buildSchema(app);
@@ -100,7 +109,7 @@ export async function buildServer() {
   // Mercurius
   await app.register(mercurius, {
     schema,
-    context: () => ({ abastecimentoService, diariasService, obrasService, suprimentoService }),
+    context: () => ({ abastecimentoService, diariasService, obrasService, suprimentoService, contratosService }),
     graphiql: isDev,
     path: '/graphql',
   });


### PR DESCRIPTION
Expõe Contratos de Repasses e Convênios no schema GraphQL. Os dados vêm do
bi-portal-data, como nos demais domínios.

## O que entra

- `src/schema/contratos/` — schema, resolver, service e types
- `src/data/loadContratos.ts` — consome `${DATA_API_URL}/api/contratos`
- `src/schema/index.ts` e `src/server.ts` — registra o resolver e injeta o
  service no context

## Contrato

| Query | Retorno |
|---|---|
| `getContratosKpi` | repasse, contrapartida, global, contratos, processos |
| `getContratosCharts` | por ano, secretaria, origem, área, fonte e situação |
| `getContratosTable` | linhas paginadas, com ordenação e filtro por coluna |
| `getContratosFiltersOptions` | opções em cascata dos 9 filtros |
| `getContratosLastUpdate` | data de referência da carga |
| `getContratos` / `getContratosSecretariaSummary` | downloads da fonte de dados |

## Notas de revisão

As agregações ficam no SQL do bi-portal-data; o service é um tradutor fino, no
mesmo formato de `obras.service.ts`. Não altera nenhum domínio existente — o
`server.ts` só ganha a inicialização do ContratosService.

O período é filtrado por **ano**, não por intervalo de datas: a origem não tem
coluna de data. Daí o `YearRangeInput` no lugar do `DateRangeInput` usado
pelos outros domínios.

**Uma diferença proposital em relação aos demais services:** aqui, pedir
`limit` sem `offset` devolve a primeira página. Nos outros domínios a
paginação é ignorada nesse caso e a lista inteira volta. Na prática o frontend
sempre envia os dois, então nada está quebrado hoje — mas vale corrigir os
demais num PR próprio.
